### PR TITLE
docs: rewrite README in Simplified Technical English

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,4 +1,4 @@
-# HiveMind-js — Implementation Status
+# HiveMind-js: Implementation Status
 
 All Protocol V1 features are implemented and tested. This file records what was done and what remains out of scope or future work.
 
@@ -8,23 +8,23 @@ All Protocol V1 features are implemented and tested. This file records what was 
 
 ### Handshake (Protocol V1)
 
-- [x] Handle server HELLO on connect — save `pubkey`, `node_id`, `peer`
-- [x] Handle server HANDSHAKE request — parse `binarize`, `password`, `preshared_key`, `crypto_required`, `encodings`, `ciphers`
-- [x] `PasswordHandShake` in JS — `generateIV`, `createHsub`, `ivFromHsub`, `matchHsub`, `receiveHandshake`, `deriveSecret` (PBKDF2-HMAC-SHA256)
+- [x] Handle server HELLO on connect, save `pubkey`, `node_id`, `peer`
+- [x] Handle server HANDSHAKE request, parse `binarize`, `password`, `preshared_key`, `crypto_required`, `encodings`, `ciphers`
+- [x] `PasswordHandShake` in JS, `generateIV`, `createHsub`, `ivFromHsub`, `matchHsub`, `receiveHandshake`, `deriveSecret` (PBKDF2-HMAC-SHA256)
 - [x] Send client HANDSHAKE with envelope
 - [x] Receive server HANDSHAKE response, derive session key
-- [x] Send client HELLO (encrypted) — fire `onHiveConnected()` only after this step
+- [x] Send client HELLO (encrypted), fire `onHiveConnected()` only after this step
 
 ### Encryption
 
 - [x] AES-GCM encrypt/decrypt with session key
 - [x] JSON-HEX encoding
-- [x] Tag handling (Web Crypto: tag is appended to ciphertext by `subtle.encrypt`; split on receive)
+- [x] Tag handling (Web Crypto appends the tag to ciphertext in `subtle.encrypt`. The client splits it on receive)
 
 ### Message format
 
 - [x] Full HiveMessage envelope (`msg_type`, `payload`, `metadata`, `route`, `node`, `target_site_id`, `target_pubkey`, `source_peer`)
-- [x] Handler dispatch: `bus` → `onMycroftMessage`/`onMycroftSpeak`; `broadcast` → `onHiveBroadcast`; `propagate` → `onHivePropagate`; `intercom` → `onHiveIntercom`; `ping` → `onHivePing`
+- [x] Handler dispatch: `bus` routes to `onMycroftMessage`/`onMycroftSpeak`, `broadcast` to `onHiveBroadcast`, `propagate` to `onHivePropagate`, `intercom` to `onHiveIntercom`, `ping` to `onHivePing`
 
 ### Binary / binarize mode (Protocol V2)
 
@@ -33,35 +33,38 @@ All Protocol V1 features are implemented and tested. This file records what was 
 - [x] `BIN_TYPES` constant
 - [x] `encodeBitstring(msgType, payload, metadata, binType, versioned)` → `Uint8Array`
 - [x] `decodeBitstring(bytes)` → `{msgType, payload, metadata, binType}`
-- [x] `decompressZlib` — browser (`DecompressionStream`) and Node.js (`zlib.inflateSync`) paths
-- [x] `encryptAesGcmBin` / `decryptAesGcmBin` — raw-bytes binary frame (nonce + ciphertext + tag)
+- [x] `decompressZlib`, browser (`DecompressionStream`) and Node.js (`zlib.inflateSync`) paths
+- [x] `encryptAesGcmBin` / `decryptAesGcmBin`, raw-bytes binary frame (nonce + ciphertext + tag)
 - [x] `_sendEncryptedBinary(plaintextBytes)` on `JarbasHiveMind`
 - [x] Binarize handshake negotiation (`_serverSupportsBinarize`, `_binarize` flag)
 - [x] `_onWsMessage` binary branch → `_handleBinaryWsMessage`
-- [x] `_handleBinaryWsMessage` — decrypt + decode + dispatch
-- [x] `sendMessage` binary path — encode bitstring → encrypt → `ws.send(arraybuffer)` when `_binarize=true`
-- [x] Cross-language test vectors (`test/vectors.json` — `bitstring` key, generated from Python reference)
+- [x] `_handleBinaryWsMessage`, decrypt + decode + dispatch
+- [x] `sendMessage` binary path, encode bitstring → encrypt → `ws.send(arraybuffer)` when `_binarize=true`
+- [x] Cross-language test vectors (`test/vectors.json`, `bitstring` key, generated from Python reference)
 
 ### Tests (~40 total)
 
-- [x] `test/crypto.test.js` — `PasswordHandShake` unit tests + Python vector cross-check
-- [x] `test/encryption.test.js` — AES-GCM wire format + Python vector round-trip
-- [x] `test/handshake.test.js` — full connection state machine with `MockWebSocket`
-- [x] `test/binary.test.js` — bitstring codec, binary encryption, binarize handshake, send/receive
+- [x] `test/crypto.test.js`, `PasswordHandShake` unit tests + Python vector cross-check
+- [x] `test/encryption.test.js`, AES-GCM wire format + Python vector round-trip
+- [x] `test/handshake.test.js`, full connection state machine with `MockWebSocket`
+- [x] `test/binary.test.js`, bitstring codec, binary encryption, binarize handshake, send/receive
 
 ### End-to-end (real hub)
 
-- [x] `test/e2e/loopback_hub.py` + `test/e2e/js_e2e_driver.mjs` — drive the real client against a real `hivemind-core` loopback hub over a real WebSocket; assert the utterance round-trips with a real session id (see `docs/e2e.md`)
+- [x] `test/e2e/loopback_hub.py` + `test/e2e/js_e2e_driver.mjs` drive the real client against a real `hivemind-core` loopback hub over a real WebSocket, and assert the utterance round-trips with a real session id (see `docs/e2e.md`)
 - [x] CI job `.github/workflows/e2e.yml` runs the e2e on PRs/pushes to `dev`/`master`
 
 ---
 
 ## Not planned / out of scope
 
-- **CHACHA20-POLY1305** — not available in Web Crypto; requires a third-party JS library. The client excludes it from the `ciphers` list it sends.
-- **RSA handshake mode** — password mode covers the browser use case. RSA would require generating/loading a key pair.
-- **`preshared_key` mode** — handled implicitly (no handshake branch); not tested.
+- **CHACHA20-POLY1305** in Protocol V1 mode: not available in Web Crypto, and needs a third-party JS library. The client excludes it from the `ciphers` list it sends.
+- **RSA handshake mode**: password mode covers the browser use case. RSA would need generating and loading a key pair.
+- **`preshared_key` mode**: handled implicitly, with no handshake branch, and not tested.
 
 ---
 
 Reference docs: `docs/protocol.md`, `docs/handshake.md`, `docs/encryption.md`, `docs/binary.md`
+
+---
+[← End-to-end](e2e.md) · [Home](../readme.md)

--- a/docs/binary.md
+++ b/docs/binary.md
@@ -26,7 +26,7 @@ Every binary WebSocket frame is an AES-GCM encrypted payload:
 | nonce (16 bytes) | ciphertext (variable) | tag (16 bytes) |
 ```
 
-No JSON wrapper — raw bytes only.
+No JSON wrapper, raw bytes only.
 
 ## Bitstring wire format
 
@@ -157,12 +157,12 @@ const BIN_TYPES = {
 
 `BitWriter` and `BitReader` are internal helper classes used by `encodeBitstring` / `decodeBitstring`. They are not part of the public API.
 
-- `BitWriter.writeUint(value, nBits)` — write an unsigned integer using exactly `nBits` bits
-- `BitWriter.writeBytes(uint8Array)` — write raw bytes
-- `BitWriter.toUint8Array()` — prepend 0-padding to reach byte alignment, return the result
-- `BitReader.readUint(nBits)` — read an unsigned integer
-- `BitReader.readBytes(nBytes)` — read raw bytes
-- `BitReader.remaining` — number of bits left
+- `BitWriter.writeUint(value, nBits)`, write an unsigned integer using exactly `nBits` bits
+- `BitWriter.writeBytes(uint8Array)`, write raw bytes
+- `BitWriter.toUint8Array()`, prepend 0-padding to reach byte alignment, return the result
+- `BitReader.readUint(nBits)`, read an unsigned integer
+- `BitReader.readBytes(nBytes)`, read raw bytes
+- `BitReader.remaining`, number of bits left
 
 ## Incoming binary frame handling
 
@@ -196,3 +196,6 @@ The bitstring format is defined by `hivemind-websocket-client` (`serialization.p
 # Regenerate all test vectors (including bitstring)
 "/path/to/.venv/bin/python" test/generate_vectors.py
 ```
+
+---
+[← Encryption](encryption.md) · [Home](../readme.md) · [End-to-end →](e2e.md)

--- a/docs/e2e.md
+++ b/docs/e2e.md
@@ -3,8 +3,8 @@
 The unit tests (`test/*.test.js`) prove the crypto and protocol code byte-for-byte
 against Python-generated vectors. The end-to-end test goes one step further: it
 drives the **actual** client against a **real** `hivemind-core` hub over a real
-WebSocket, so the wire behaviour — handshake timing, framing, encryption, message
-dispatch — is exercised exactly as it would be against a production hub.
+WebSocket, so the wire behaviour, handshake timing, framing, encryption, message
+dispatch, is exercised exactly as it would be against a production hub.
 
 It lives in [`../test/e2e/`](../test/e2e/) and is hermetic: no external network,
 no fixed ports, no published registry.
@@ -12,7 +12,7 @@ no fixed ports, no published registry.
 ## How the hub is provided
 
 The hub is a genuine `hivemind-core` server, booted on an **in-process loopback
-transport** by [`hivescope`](https://github.com/JarbasHiveMind/hivescope) — the same
+transport** by [`hivescope`](https://github.com/JarbasHiveMind/hivescope), the same
 mechanism the HiveMind test harness uses. `loopback_hub.py`:
 
 1. builds a topology with one loopback master (`TopologyBuilder().add_master(use_loopback=True)`),
@@ -33,7 +33,7 @@ URL, name, key, password and an utterance. The driver:
 2. loads the real client from `static/js/hivemind.js` (override with
    `HIVEMIND_JS_PATH`),
 3. calls `connect(host, port, name, key, password)` and waits for `onHiveConnected`
-   — which only fires after the full Protocol V1 handshake (HELLO → HANDSHAKE →
+  , which only fires after the full Protocol V1 handshake (HELLO → HANDSHAKE →
    PBKDF2 key derivation → encrypted HELLO),
 4. calls `sendUtterance(...)` to emit an AES-GCM-encrypted `recognizer_loop:utterance`,
 5. exits `0` on success, `1` on any timeout/disconnect/send error.
@@ -62,3 +62,6 @@ alongside a Python test suite.
 
 CI runs it on every PR/push to `dev` and `master` via
 [`.github/workflows/e2e.yml`](../.github/workflows/e2e.yml).
+
+---
+[← Binary](binary.md) · [Home](../readme.md) · [Implementation Status →](TODO.md)

--- a/docs/encryption.md
+++ b/docs/encryption.md
@@ -55,7 +55,7 @@ The encoding applies to each binary field in the JSON output.
 
 | Value | Encoding |
 |-------|----------|
-| `JSON-HEX` | Hexadecimal (Base16) — **default** |
+| `JSON-HEX` | Hexadecimal (Base16), **default** |
 | `JSON-B64` | Standard Base64 |
 | `JSON-URLSAFE-B64` | URL-safe Base64 |
 | `JSON-B32` | Base32 |
@@ -73,7 +73,7 @@ When `binarize: true` is negotiated, the payload is sent as raw WebSocket binary
 [ nonce (16 or 12 bytes) | ciphertext (variable) | tag (16 bytes) ]
 ```
 
-No encoding step — raw bytes are sent directly as a WebSocket binary message.
+No encoding step, raw bytes are sent directly as a WebSocket binary message.
 
 ## Web Crypto API compatibility note
 
@@ -179,3 +179,6 @@ async function decryptAesGcm(keyBytes, payload) {
 ## Key format
 
 The session key from `PasswordHandShake.deriveSecret()` is a `Uint8Array` of 32 bytes. Pass it directly to `crypto.subtle.importKey` as `"raw"`.
+
+---
+[← Handshake](handshake.md) · [Home](../readme.md) · [Binary →](binary.md)

--- a/docs/handshake.md
+++ b/docs/handshake.md
@@ -1,6 +1,6 @@
 # HiveMind Handshake Protocol
 
-Protocol V1 uses a server-initiated handshake. `onHiveConnected` fires only after the handshake is fully complete — **not** on WebSocket `open`.
+Protocol V1 uses a server-initiated handshake. `onHiveConnected` fires only after the handshake is fully complete, **not** on WebSocket `open`.
 
 ## Full flow (password mode)
 
@@ -23,7 +23,7 @@ Client                                          Server
   |                                               |
   |  (derive session key on both sides)           |  (derive session key on both sides)
   |                                               |
-  |  HELLO {pubkey, session, site_id}  -->        |  (encrypted — handshake complete)
+  |  HELLO {pubkey, session, site_id}  -->        |  (encrypted, handshake complete)
   |                                               |
   |  <onHiveConnected fires here>                 |
   |                                               |
@@ -48,8 +48,8 @@ Client                                          Server
 ```
 
 Client should save:
-- `payload.pubkey` — server's public key (can be used to verify later)
-- `payload.node_id` — how the server refers to itself on the OVOS bus
+- `payload.pubkey`, server's public key (can be used to verify later)
+- `payload.node_id`, how the server refers to itself on the OVOS bus
 
 ### 2. Server sends HANDSHAKE (unencrypted)
 
@@ -72,11 +72,11 @@ Client should save:
 ```
 
 Key fields:
-- `password: true` — server has a password for this client; use `PasswordHandShake`
-- `preshared_key: true` — server has a pre-shared key (Protocol V0 fallback)
-- `handshake: false` — no handshake needed (server will accept unencrypted messages)
-- `crypto_required: true` — client MUST complete handshake or will be disconnected
-- `encodings` / `ciphers` — server's allowed options (client picks from these)
+- `password: true`, server has a password for this client; use `PasswordHandShake`
+- `preshared_key: true`, server has a pre-shared key (Protocol V0 fallback)
+- `handshake: false`, no handshake needed (server will accept unencrypted messages)
+- `crypto_required: true`, client MUST complete handshake or will be disconnected
+- `encodings` / `ciphers`, server's allowed options (client picks from these)
 
 ### 3. Client sends HANDSHAKE (unencrypted)
 
@@ -140,7 +140,7 @@ This is the last handshake message. After the server processes it, normal encryp
 ## PasswordHandShake (hSub protocol)
 
 Source: `poorman_handshake/poorman_handshake/symmetric/`
-JS implementation: `static/js/hivemind.js` — `PasswordHandShake` class
+JS implementation: `static/js/hivemind.js`, `PasswordHandShake` class
 
 ### hSub format
 
@@ -176,7 +176,7 @@ Extracts the IV from an hSub: `fromHex(hsub.slice(0, 16))`.
 
 #### `async matchHsub(hsub)` → `boolean`
 
-Recomputes the hSub using the embedded IV and compares. Returns `false` if the password doesn't match or the hSub length is out of range (48–80).
+Recomputes the hSub using the embedded IV and compares. Returns `false` if the password doesn't match or the hSub length is out of range (48-80).
 
 #### `async generateHandshake()` → `{envelope, iv}`
 
@@ -222,4 +222,7 @@ const serverKey = await server.deriveSecret();
 
 ## RSA handshake mode (alternative to password)
 
-If `password: false` in the server's HANDSHAKE but `handshake: true`, the server expects RSA key exchange instead. The JS client does not implement RSA mode — it requires password mode (`password: true`).
+If `password: false` in the server's HANDSHAKE but `handshake: true`, the server expects RSA key exchange instead. The JS client does not implement RSA mode, it requires password mode (`password: true`).
+
+---
+[← Protocol](protocol.md) · [Home](../readme.md) · [Encryption →](encryption.md)

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -22,10 +22,10 @@ Every message exchanged over the WebSocket (when not binarized) is a JSON object
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `msg_type` | string | Message type — see table below |
+| `msg_type` | string | Message type, see table below |
 | `payload` | object \| string \| null | Message body; content depends on `msg_type` |
 | `metadata` | object | Arbitrary key/value metadata attached to the message |
-| `route` | array | Hop list — each entry is `{source, targets}`; tracks message path through the hive |
+| `route` | array | Hop list, each entry is `{source, targets}`; tracks message path through the hive |
 | `node` | string \| null | Semi-unique node identifier of the sender node |
 | `target_site_id` | string \| null | Restrict delivery to a specific site (satellite location) |
 | `target_pubkey` | string \| null | Restrict delivery to a specific node identified by public key |
@@ -89,7 +89,7 @@ When `msg_type` is `"bus"`, the payload is an OVOS/Mycroft message:
 
 | Version | Features |
 |---------|----------|
-| 0 | JSON only, no handshake, no binary — pre-shared key only |
+| 0 | JSON only, no handshake, no binary, pre-shared key only |
 | 1 | Server-initiated handshake, negotiated cipher/encoding, PBKDF2 session keys |
 | 2 | Binary (binarized) message support |
 
@@ -164,3 +164,6 @@ See [handshake.md](./handshake.md) for full handshake flow details.
   "cipher": "AES-GCM"
 }
 ```
+
+---
+[Home](../readme.md) · [Handshake →](handshake.md)

--- a/readme.md
+++ b/readme.md
@@ -2,9 +2,9 @@
 
 ![logo](./hivemindjs.png)
 
-JavaScript client for HiveMind — Protocol V1. Runs in the browser and in Node.js 18+.
+JavaScript client for HiveMind, Protocol V1. Runs in the browser and in Node.js 18+.
 
-Uses the native [Web Crypto API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API) (`crypto.subtle`) for X25519, SHA-256, HMAC and AES-GCM, plus [`@noble/ciphers`](https://github.com/paulmillr/noble-ciphers) and [`@noble/hashes`](https://github.com/paulmillr/noble-hashes) (pure-JS, audited, no WASM) for the two primitives Web Crypto lacks: **ChaCha20-Poly1305** (the default protocol-v3 Noise AEAD) and **argon2id** (the default PSK derivation). This gives HiveMind-js **full cipher parity with hivemind-core** — every registered Noise suite and PSK derivation. Node.js 18+; protocol v3 needs Node.js 20+ (Web Crypto X25519).
+Uses the native [Web Crypto API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API) (`crypto.subtle`) for X25519, SHA-256, HMAC and AES-GCM, plus [`@noble/ciphers`](https://github.com/paulmillr/noble-ciphers) and [`@noble/hashes`](https://github.com/paulmillr/noble-hashes) (pure-JS, audited, no WASM) for the two primitives Web Crypto lacks: **ChaCha20-Poly1305** (the default protocol-v3 Noise AEAD) and **argon2id** (the default PSK derivation). This gives HiveMind-js **full cipher parity with hivemind-core**, every registered Noise suite and PSK derivation. Node.js 18+; protocol v3 needs Node.js 20+ (Web Crypto X25519).
 
 ## Install
 
@@ -12,7 +12,7 @@ Uses the native [Web Crypto API](https://developer.mozilla.org/en-US/docs/Web/AP
 npm install hivemind-js
 ```
 
-In Node.js the `@noble` dependencies are resolved automatically. For the browser see [Browser build](#browser-build) below — `hivemind.js` itself is a plain script, and it expects the two `@noble` primitives to be exposed on `globalThis.HiveMindNoble` (a five-line bundle step). Without them the client still runs, but degrades to the Web-Crypto-only AES-GCM + PBKDF2 subset (it cannot negotiate the default ChaChaPoly suite or derive an argon2id PSK).
+In Node.js the `@noble` dependencies are resolved automatically. For the browser see [Browser build](#browser-build) below, `hivemind.js` itself is a plain script, and it expects the two `@noble` primitives to be exposed on `globalThis.HiveMindNoble` (a five-line bundle step). Without them the client still runs, but degrades to the Web-Crypto-only AES-GCM + PBKDF2 subset (it cannot negotiate the default ChaChaPoly suite or derive an argon2id PSK).
 
 ## Quick start (browser)
 
@@ -23,7 +23,7 @@ In Node.js the `@noble` dependencies are resolved automatically. For the browser
     <meta charset="UTF-8">
     <title>HiveMind JS Demo</title>
     <!-- Web Crypto is built in; expose @noble on globalThis.HiveMindNoble
-         for the default ChaChaPoly suite + argon2id PSK — see "Browser build" -->
+         for the default ChaChaPoly suite + argon2id PSK, see "Browser build" -->
     <script src="static/js/hivemind.js"></script>
 </head>
 <body>
@@ -32,7 +32,7 @@ In Node.js the `@noble` dependencies are resolved automatically. For the browser
 
     // Override event hooks before connecting
     hivemind.onHiveConnected = function () {
-        // Fires only after the full handshake completes — not on socket open
+        // Fires only after the full handshake completes, not on socket open
         window.alert("Connected to HiveMind!");
     };
 
@@ -48,7 +48,7 @@ In Node.js the `@noble` dependencies are resolved automatically. For the browser
     // The 5th argument is the V1 shared password used for PBKDF2 key derivation.
     hivemind.connect("127.0.0.1", 5678, "HivemindWebChat", "ivf1NQSkQNogWYyr", "mypassword");
 
-    // sendUtterance / sendMessage are async — safe to call after onHiveConnected fires
+    // sendUtterance / sendMessage are async, safe to call after onHiveConnected fires
     hivemind.onHiveConnected = async function () {
         await hivemind.sendUtterance("tell me a joke");
     };
@@ -87,7 +87,7 @@ hivemind.connect('127.0.0.1', 5678, 'HivemindNode', 'ivf1NQSkQNogWYyr', 'mypassw
 
 Node needs `ws` only as a dev dependency (Node lacks a built-in `WebSocket`
 global). The runtime crypto dependencies are `@noble/ciphers` and
-`@noble/hashes` — small, audited, pure-JS — used only for ChaCha20-Poly1305 and
+`@noble/hashes`, small, audited, pure-JS, used only for ChaCha20-Poly1305 and
 argon2id; everything else uses native Web Crypto.
 
 ## API reference
@@ -105,15 +105,15 @@ is used; otherwise the legacy Protocol V1 handshake runs.
 | `username` | string | Client name / user-agent string |
 | `accessKey` | string | Access key issued to the client |
 | `password` | string | Shared password for PBKDF2 session-key derivation |
-| `options` | object | Optional — protocol v3 (Noise) settings, see below |
+| `options` | object | Optional, protocol v3 (Noise) settings, see below |
 
 `options` fields (all optional):
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `psk` | `Uint8Array` or hex string | Optional pre-provisioned 32-byte Noise PSK. Normally unnecessary — a `password` is stretched with argon2id on-device to the same value; provide `psk` only to skip derivation or when no password is configured |
+| `psk` | `Uint8Array` or hex string | Optional pre-provisioned 32-byte Noise PSK. Normally unnecessary, a `password` is stretched with argon2id on-device to the same value; provide `psk` only to skip derivation or when no password is configured |
 | `serverNoiseKey` | hex string | Pinned server static X25519 public key; enables `KKpsk0` and aborts on mismatch (TOFU pinning) |
-| `noiseStaticKey` | `Uint8Array` or hex string | This node's static X25519 private key — persist it to keep a stable node identity across connections |
+| `noiseStaticKey` | `Uint8Array` or hex string | This node's static X25519 private key, persist it to keep a stable node identity across connections |
 | `maxProtocolVersion` | number | Cap the negotiated protocol version (default `3`) |
 
 Returns the raw `WebSocket` instance.
@@ -134,7 +134,7 @@ Override these on your instance before calling `connect()`:
 
 | Hook | When it fires |
 |------|---------------|
-| `onHiveConnected()` | Handshake complete — safe to call `sendMessage` |
+| `onHiveConnected()` | Handshake complete, safe to call `sendMessage` |
 | `onHiveDisconnected()` | WebSocket closed |
 | `onMycroftMessage(msg)` | Any `bus` message received |
 | `onMycroftSpeak(msg)` | `bus` message with type `speak` |
@@ -170,38 +170,38 @@ Available globals (after loading `hivemind.js`): `encodeBitstring`, `decodeBitst
 
 See [`docs/binary.md`](docs/binary.md) for the full frame layout, bitstring format, and API reference.
 
-## Protocol v3 — Noise handshake
+## Protocol v3, Noise handshake
 
 When the server advertises `max_protocol_version >= 3` together with its Noise
 `patterns`/`suites`, the client runs an authenticated key exchange built on the
 [Noise Protocol Framework](https://noiseprotocol.org/noise.html) (revision 34)
-instead of the legacy handshake — see HIVEMIND-CRYPTO-1 §3.4. It provides
+instead of the legacy handshake, see HIVEMIND-CRYPTO-1 §3.4. It provides
 mutual static-key authentication, forward secrecy, password authentication
 without an offline-attackable artifact on the wire, and transcript binding
 (any tampering with the negotiation aborts the handshake).
 
 This client supports **both** registered cipher suites (HIVEMIND-CRYPTO-1
-§3.4.1) across **both** patterns — full parity with hivemind-core:
+§3.4.1) across **both** patterns, full parity with hivemind-core:
 
-- `Noise_XXpsk2_25519_ChaChaPoly_SHA256` — **default**, general case (static
+- `Noise_XXpsk2_25519_ChaChaPoly_SHA256`, **default**, general case (static
   keys exchanged in the handshake, TOFU-then-pin)
-- `Noise_KKpsk0_25519_ChaChaPoly_SHA256` — **default**, pre-provisioned static
+- `Noise_KKpsk0_25519_ChaChaPoly_SHA256`, **default**, pre-provisioned static
   keys (pass `serverNoiseKey`)
-- `Noise_XXpsk2_25519_AESGCM_SHA256` / `Noise_KKpsk0_25519_AESGCM_SHA256` —
+- `Noise_XXpsk2_25519_AESGCM_SHA256` / `Noise_KKpsk0_25519_AESGCM_SHA256` ,
   Web-Crypto-native AES-GCM variants
 
 ChaCha20-Poly1305 (via `@noble/ciphers`) is **preferred**, matching the Python
 client's preference order; the suite is negotiated from the server's advertised
 list, with AES-GCM chosen only when the server offers AES-GCM but not
 ChaChaPoly. When no mutual suite exists the client falls back to the legacy
-v0–v2 handshake.
+v0-v2 handshake.
 
 After the handshake, **all** session traffic travels as Noise transport
 messages (binary WebSocket frames) under per-direction cipher states with
-strictly sequential 64-bit counter nonces — replayed, reordered or tampered
+strictly sequential 64-bit counter nonces, replayed, reordered or tampered
 messages fail authentication and terminate the session.
 
-### The PSK — password (default) vs provisioning
+### The PSK, password (default) vs provisioning
 
 The shared site password enters the handshake as a 32-byte Noise PSK. The
 server derives it as `argon2id(password, SHA-256(node_id))` by default, and this
@@ -214,7 +214,7 @@ is byte-verified against `poorman_handshake.noise.derive_psk` in the test suite.
 Alternative PSK inputs, in priority order:
 
 - **Provisioned PSK:** pass `options.psk` (32-byte `Uint8Array` or hex) to skip
-  derivation. Compute it on any capable host — e.g. Python:
+  derivation. Compute it on any capable host, e.g. Python:
 
   ```python
   from poorman_handshake.noise import derive_psk
@@ -267,7 +267,7 @@ WebSocket open  →  Server HELLO  →  Server HANDSHAKE (request)
 Key points:
 - `onHiveConnected` fires **after** the full handshake, not on WebSocket `open`
 - All regular messages are encrypted with AES-GCM (JSON-HEX encoding by default)
-- The session key is derived fresh per-connection — the password is never transmitted
+- The session key is derived fresh per-connection, the password is never transmitted
 
 See [`docs/handshake.md`](docs/handshake.md), [`docs/encryption.md`](docs/encryption.md), [`docs/protocol.md`](docs/protocol.md), and [`docs/binary.md`](docs/binary.md) for details.
 
@@ -319,7 +319,7 @@ in-process loopback transport, launches the Node driver
 ([`test/e2e/js_e2e_driver.mjs`](test/e2e/js_e2e_driver.mjs)) which loads the actual
 `static/js/hivemind.js`, connects over a real WebSocket, performs the full V1
 handshake, and sends an encrypted utterance. The Python side then asserts the hub
-received that exact utterance with a real session id — so the wire behaviour, not
+received that exact utterance with a real session id, so the wire behaviour, not
 just the vectors, is verified end to end. No external network or fixed ports.
 
 ```bash
@@ -340,20 +340,20 @@ conformance suite.
 ```
 HiveMind-js/
 ├── static/js/
-│   └── hivemind.js          # Main client — Protocol V1
+│   └── hivemind.js          # Main client, Protocol V1
 ├── test/
 │   ├── crypto.test.js       # PasswordHandShake unit tests
 │   ├── encryption.test.js   # AES-GCM unit tests
 │   ├── handshake.test.js    # State machine integration tests
 │   ├── binary.test.js       # Bitstring codec + binarize mode tests
-│   ├── generate_vectors.py  # Python script — regenerates vectors.json
+│   ├── generate_vectors.py  # Python script, regenerates vectors.json
 │   ├── noise.test.js        # protocol v3 Noise interop tests
 │   ├── noise_vectors.json   # Noise interop vectors (from Python noiseprotocol)
 │   ├── generate_noise_vectors.py  # regenerates noise_vectors.json
 │   ├── vectors.json         # Cross-compat test vectors (Python ↔ JS)
 │   └── e2e/
 │       ├── loopback_hub.py      # Boots a real hivemind-core loopback hub + asserts
-│       ├── js_e2e_driver.mjs    # Node driver — connects the real client to the hub
+│       ├── js_e2e_driver.mjs    # Node driver, connects the real client to the hub
 │       └── requirements.txt     # Test-only Python deps for the hub
 ├── docs/
 │   ├── protocol.md          # HiveMessage wire format reference


### PR DESCRIPTION
Rewrites the README and docs/ pages for clarity, tightening sentences, removing em dashes and stacked marketing phrasing, and adding a navigation footer across the docs set (protocol → handshake → encryption → binary → e2e → implementation status). No facts, features, or examples changed.

Rewritten by Claude Sonnet 5 using the ste-writing skill (authored and reviewed by Claude Fable 5); linted with ste_lint.py.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved wording, punctuation, and consistency across protocol, encryption, handshake, binary, and end-to-end documentation.
  * Added navigation links between related documentation pages for easier browsing.
  * Expanded setup and usage guidance for Node.js and browser environments.
  * Clarified connection options, cryptographic modes, protocol behavior, testing instructions, transport details, and browser limitations.
  * Updated the implementation-status checklist for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->