### PR TITLE
feat!: remove the 3rdparty message type

### DIFF
--- a/docs/binary.md
+++ b/docs/binary.md
@@ -61,7 +61,6 @@ The leading 1 bit (`pad marker`) terminates the byte-alignment padding. Bits are
 | 8 | `cascade` |
 | 9 | `ping` |
 | 10 | `rendezvous` |
-| 11 | `3rdparty` |
 | 12 | `bin` |
 
 ### Binary sub-types (`bin_type`)

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -66,7 +66,6 @@ Every message exchanged over the WebSocket (when not binarized) is a JSON object
 | `"cascade"` | `CASCADE` | master→slaves | Like propagate, expects responses from all nodes |
 | `"ping"` | `PING` | both | Like cascade, used for network topology mapping |
 | `"rendezvous"` | `RENDEZVOUS` | both | Reserved for rendezvous-nodes |
-| `"3rdparty"` | `THIRDPRTY` | both | User-land message with no defined handling |
 | `"bin"` | `BINARY` | both | Binary data container (payload is raw bytes, not JSON) |
 
 ## BUS payload format

--- a/static/js/hivemind.js
+++ b/static/js/hivemind.js
@@ -135,7 +135,7 @@ async function decryptAesGcmBin(keyBytes, frame) {
 const MSG_TYPE_TO_INT = {
     shake: 0, bus: 1, shared_bus: 2, broadcast: 3, propagate: 4,
     escalate: 5, hello: 6, query: 7, cascade: 8, ping: 9,
-    rendezvous: 10, '3rdparty': 11, bin: 12
+    rendezvous: 10, bin: 12
 };
 
 const INT_TO_MSG_TYPE = Object.fromEntries(
@@ -300,7 +300,12 @@ async function decodeBitstring(bytes) {
     }
 
     const msgTypeInt = r.readUint(5);
-    const msgType = INT_TO_MSG_TYPE[msgTypeInt] || '3rdparty';
+    const msgType = INT_TO_MSG_TYPE[msgTypeInt];
+    if (msgType === undefined) {
+        // WIRE-1 §4.2: reject an unassigned message-type code as malformed.
+        // Code 11 was '3rdparty', which is removed; do not reuse it.
+        throw new Error(`decodeBitstring: unassigned message type code ${msgTypeInt}`);
+    }
     const compressed = r.readBit() === 1;
 
     const metaLen = r.readUint(8);

--- a/test/binary.test.js
+++ b/test/binary.test.js
@@ -136,13 +136,17 @@ describe('Bitstring codec', () => {
         // (already covered by round-trip tests)
     });
 
-    test('MSG_TYPE_TO_INT covers all 13 known types', () => {
+    test('MSG_TYPE_TO_INT covers all 12 known types', () => {
         const expected = ['shake','bus','shared_bus','broadcast','propagate','escalate',
-                          'hello','query','cascade','ping','rendezvous','3rdparty','bin'];
+                          'hello','query','cascade','ping','rendezvous','bin'];
         for (const t of expected) {
             assert.ok(MSG_TYPE_TO_INT[t] !== undefined, `${t} must be in MSG_TYPE_TO_INT`);
         }
-        assert.equal(Object.keys(MSG_TYPE_TO_INT).length, 13);
+        assert.equal(Object.keys(MSG_TYPE_TO_INT).length, 12);
+    });
+
+    test('code 11 is unassigned and no type maps to it', () => {
+        assert.equal(Object.values(MSG_TYPE_TO_INT).includes(11), false);
     });
 
     test('BIN_TYPES.RAW_AUDIO === 1', () => {


### PR DESCRIPTION
Part of the removal of the `THIRDPRTY` message type. Client library: JarbasHiveMind/hivemind-websocket-client#160. Spec: architecture `1b160f3`.

## Changes

- `static/js/hivemind.js` — drops `'3rdparty': 11` from `MSG_TYPE_TO_INT`, and `decodeBitstring` now throws on an unassigned message-type code instead of `|| '3rdparty'`. That fallback was the same silent-coercion bug the Python client fixed in #151: it masked a corrupt or forged frame.
- `docs/binary.md`, `docs/protocol.md` — the type leaves both tables.
- `test/binary.test.js` — the coverage test drops to 12 types, plus a new test that no type maps to code 11.

Wire code 11 is now unassigned. Do not reuse it: a new type takes the next free code from 13.

## Tests

`node --test test/*.test.js`: **60 pass, 13 fail**. The same 13 fail on `origin/dev` before this change (noise/crypto suites); this branch adds one passing test and breaks nothing. I did not chase the pre-existing failures.

`test/vectors.json` needed no regeneration — every vector uses `msg_type: "bus"`.