### PR TITLE
docs: correct claims that no longer match the code

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -119,11 +119,12 @@ The `JarbasHiveMind` class in `static/js/hivemind.js` implements:
 | Feature | Supported |
 |---------|-----------|
 | Protocol V1 (server-initiated handshake) | Yes |
+| Protocol V3 (Noise, argon2id PSK derivation) | Yes, `_maxProtocolVersion` is 3 by default |
 | Password mode (`PasswordHandShake`) | Yes |
 | AES-GCM cipher | Yes |
 | JSON-HEX encoding | Yes |
 | RSA key exchange | No |
-| ChaCha20-Poly1305 cipher | No (not in Web Crypto) |
+| ChaCha20-Poly1305 cipher | Yes, via `@noble/ciphers` (Web Crypto has no ChaCha20) |
 | Binary / binarize mode | Yes |
 
 ## HANDSHAKE payload formats

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 ![logo](./hivemindjs.png)
 
-JavaScript client for HiveMind, Protocol V1. Runs in the browser and in Node.js 18+.
+JavaScript client for HiveMind, up to protocol v3 (Noise with argon2id PSK derivation). Runs in the browser and in Node.js 18+.
 
 Uses the native [Web Crypto API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API) (`crypto.subtle`) for X25519, SHA-256, HMAC and AES-GCM, plus [`@noble/ciphers`](https://github.com/paulmillr/noble-ciphers) and [`@noble/hashes`](https://github.com/paulmillr/noble-hashes) (pure-JS, audited, no WASM) for the two primitives Web Crypto lacks: **ChaCha20-Poly1305** (the default protocol-v3 Noise AEAD) and **argon2id** (the default PSK derivation). This gives HiveMind-js **full cipher parity with hivemind-core**, every registered Noise suite and PSK derivation. Node.js 18+; protocol v3 needs Node.js 20+ (Web Crypto X25519).
 


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 5 (claude-opus-5) via Claude Code — NOT human-reviewed. Verify before acting.

Part of an ecosystem-wide documentation accuracy pass. Five audit passes cross-checked every documented claim against freshly-synced `dev` source; this branch carries the corrections for this repo. Each fix cites the source that disproves the old wording.

Two findings turned out to be **code** bugs rather than doc bugs, and are reported separately rather than papered over here:
- the MicroPython client answers PING with a `pong` frame using wire code 13, which is unassigned in the reference `_INT2TYPE`, so a reference decoder rejects it;
- `emit_intercom` sends a hybrid envelope (`encrypted_key`/`ciphertext`/`tag`/`nonce`) while hivemind-core RSA-decrypts the `ciphertext` field directly, so an INTERCOM addressed to the hub itself cannot be decrypted. Peer-to-peer INTERCOM relayed through the hub is unaffected.