### PR TITLE
fix: let the client reach a real hub, and hear the answer

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,17 +13,18 @@
     "url": "https://github.com/JarbasHiveMind/HiveMind-js/issues"
   },
   "main": "static/js/hivemind.js",
-  "module": "static/js/hivemind.js",
+  "module": "static/js/hivemind.mjs",
   "exports": {
     ".": {
       "require": "./static/js/hivemind.js",
-      "import": "./static/js/hivemind.js",
+      "import": "./static/js/hivemind.mjs",
       "default": "./static/js/hivemind.js"
     }
   },
   "browser": "static/js/hivemind.js",
   "files": [
     "static/js/hivemind.js",
+    "static/js/hivemind.mjs",
     "docs",
     "readme.md",
     "LICENSE"

--- a/readme.md
+++ b/readme.md
@@ -80,6 +80,7 @@ hivemind.onHiveConnected = async () => {
 };
 
 hivemind.onMycroftSpeak = (msg) => console.log('speak:', msg.data.utterance);
+// fires for the spec topic 'ovos.utterance.speak' and the legacy 'speak'
 
 // connect(host, port, username, accessKey, password)
 hivemind.connect('127.0.0.1', 5678, 'HivemindNode', 'ivf1NQSkQNogWYyr', 'mypassword');
@@ -100,7 +101,7 @@ is used; otherwise the legacy Protocol V1 handshake runs.
 
 | Argument | Type | Description |
 |----------|------|-------------|
-| `host` | string | Server hostname or IP |
+| `host` | string | Server hostname or IP. May carry its own scheme (`wss://hive.example.org`); a bare host uses `options.ssl` |
 | `port` | number | Server port (default HiveMind port: 5678) |
 | `username` | string | Client name / user-agent string |
 | `accessKey` | string | Access key issued to the client |
@@ -115,6 +116,7 @@ is used; otherwise the legacy Protocol V1 handshake runs.
 | `serverNoiseKey` | hex string | Pinned server static X25519 public key; enables `KKpsk0` and aborts on mismatch (TOFU pinning) |
 | `noiseStaticKey` | `Uint8Array` or hex string | This node's static X25519 private key, persist it to keep a stable node identity across connections |
 | `maxProtocolVersion` | number | Cap the negotiated protocol version (default `3`) |
+| `ssl` | boolean | Connect with `wss://` instead of `ws://` for a bare `host` (default `false`). A browser on an HTTPS page cannot open a `ws://` socket at all, so any hub reached from a hosted page needs this or a `wss://` host |
 
 Returns the raw `WebSocket` instance.
 

--- a/static/js/hivemind.js
+++ b/static/js/hivemind.js
@@ -991,7 +991,20 @@ JarbasHiveMind.prototype.connect = function (host, port, username, accessKey, pa
     this._noiseTransport = null;
 
     var authToken = btoa(username + ':' + accessKey);
-    var url = 'ws://' + host + ':' + port + '?authorization=' + authToken;
+    // A hardcoded 'ws://' cannot reach any hub behind TLS, and a browser on an
+    // HTTPS page refuses a ws:// socket outright as mixed content — so the
+    // client could not be used from the one place it exists for. `host` may
+    // therefore carry its own scheme ('wss://hive.example.org'); otherwise
+    // `options.ssl` picks one, defaulting to plain ws for local hubs.
+    var scheme;
+    if (/^wss?:\/\//.test(host)) {
+        scheme = '';
+    } else if (options.ssl) {
+        scheme = 'wss://';
+    } else {
+        scheme = 'ws://';
+    }
+    var url = scheme + host + ':' + port + '?authorization=' + authToken;
     this.ws = new WebSocket(url);
     this.ws.onopen    = this._onWsOpen.bind(this);
     this.ws.onmessage = this._onWsMessage.bind(this);
@@ -1350,7 +1363,15 @@ JarbasHiveMind.prototype._handleUserMessage = function (msg) {
     if (msgType === 'bus') {
         var mycMsg = msg.payload;
         this.onMycroftMessage(mycMsg);
-        if (mycMsg && mycMsg.type === 'speak') {
+        // OVOS-PIPELINE-1 §9.6 renamed the spoken-response topic to
+        // 'ovos.utterance.speak'. Python clients never noticed, because
+        // ovos-bus-client rewrites the legacy name for its subscribers; this
+        // client has no such shim, so matching only 'speak' meant
+        // onMycroftSpeak never fired against a current hub. Both names are
+        // accepted: the spec one is what hubs emit now, the legacy one keeps
+        // older hubs working.
+        if (mycMsg && (mycMsg.type === 'ovos.utterance.speak'
+                       || mycMsg.type === 'speak')) {
             this.onMycroftSpeak(mycMsg);
         }
     } else if (msgType === 'broadcast') {

--- a/static/js/hivemind.mjs
+++ b/static/js/hivemind.mjs
@@ -1,0 +1,26 @@
+// ESM entry point.
+//
+// hivemind.js is a single CommonJS/browser-global file, and package.json
+// pointed its "import" condition straight at it. Node resolves that as CJS, so
+// the `import { JarbasHiveMind } from 'hivemind-js'` the readme documents threw
+// "Named export not found" — the ESM half of the package was advertised but
+// never existed. This wrapper is that half: it re-exports the same objects, so
+// there is one implementation and no second copy to drift.
+
+import mod from './hivemind.js';
+
+export const {
+    JarbasHiveMind, PasswordHandShake, States,
+    encryptAesGcm, decryptAesGcm,
+    encryptAesGcmBin, decryptAesGcmBin,
+    encodeBitstring, decodeBitstring,
+    BIN_TYPES, MSG_TYPE_TO_INT, INT_TO_MSG_TYPE,
+    NoiseHandshake, NoiseTransport, NoiseCipherState, NoiseSymmetricState,
+    selectNoiseOptions, buildNoisePrologue, canonicalJson,
+    derivePskPBKDF2, derivePskArgon2,
+    noiseHkdf, x25519, x25519PublicFromPrivate,
+    NOISE_PATTERN_XX, NOISE_PATTERN_KK,
+    NOISE_SUITE_CHACHA, NOISE_SUITE_AESGCM, NOISE_SUITES_JS
+} = mod;
+
+export default mod;

--- a/test/real_hub.test.js
+++ b/test/real_hub.test.js
@@ -1,0 +1,95 @@
+'use strict';
+
+// Three ways this client could not talk to a hub that actually exists.
+// All three were observed against the live hub at hivemind.openvoiceos.pt.
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+const { execFileSync } = require('node:child_process');
+const path = require('node:path');
+
+let _lastMockWs = null;
+
+class MockWebSocket {
+    constructor(url) {
+        this.url = url;
+        this.sent = [];
+        _lastMockWs = this;
+    }
+    send(data) { this.sent.push(data); }
+    close() {}
+}
+
+globalThis.WebSocket = MockWebSocket;
+const { JarbasHiveMind } = require('../static/js/hivemind.js');
+
+function connect(host, options) {
+    const hm = new JarbasHiveMind();
+    hm.connect(host, 443, 'user', 'key', 'password', options);
+    return _lastMockWs.url;
+}
+
+describe('reaching a hub behind TLS', () => {
+    test('a wss:// host keeps its scheme', () => {
+        // Hardcoding ws:// made every public hub unreachable, and a browser on
+        // an HTTPS page refuses a ws:// socket as mixed content.
+        const url = connect('wss://hivemind.openvoiceos.pt');
+        assert.ok(url.startsWith('wss://hivemind.openvoiceos.pt:443'),
+                  `scheme was rewritten: ${url}`);
+        assert.ok(!url.includes('ws://wss'), `scheme was doubled: ${url}`);
+    });
+
+    test('options.ssl selects wss for a bare host', () => {
+        const url = connect('hivemind.openvoiceos.pt', { ssl: true });
+        assert.ok(url.startsWith('wss://'), url);
+    });
+
+    test('a bare host still defaults to plain ws', () => {
+        // Local hubs are the common case and have no certificate.
+        const url = connect('127.0.0.1');
+        assert.ok(url.startsWith('ws://127.0.0.1:443'), url);
+    });
+});
+
+describe('hearing the answer', () => {
+    function speakSeenFor(type) {
+        const hm = new JarbasHiveMind();
+        let heard = null;
+        hm.onMycroftSpeak = (m) => { heard = m.data.utterance; };
+        hm._handleUserMessage({
+            msg_type: 'bus',
+            payload: { type, data: { utterance: 'Hello world' } },
+        });
+        return heard;
+    }
+
+    test('the spec topic ovos.utterance.speak fires onMycroftSpeak', () => {
+        // OVOS-PIPELINE-1 §9.6. This is what a current hub emits, and matching
+        // only the legacy name meant the callback never fired at all.
+        assert.equal(speakSeenFor('ovos.utterance.speak'), 'Hello world');
+    });
+
+    test('the legacy topic speak still fires it', () => {
+        assert.equal(speakSeenFor('speak'), 'Hello world');
+    });
+
+    test('an unrelated bus message does not', () => {
+        assert.equal(speakSeenFor('ovos.utterance.handled'), null);
+    });
+});
+
+describe('importing the package', () => {
+    test('the documented ESM import resolves', () => {
+        // package.json advertised an "import" condition pointing at a
+        // CommonJS file, so `import { JarbasHiveMind } from 'hivemind-js'`
+        // threw "Named export not found".
+        const entry = path.join(__dirname, '..', 'static', 'js', 'hivemind.mjs');
+        const out = execFileSync(process.execPath, [
+            '--input-type=module', '-e',
+            `import { JarbasHiveMind } from ${JSON.stringify(entry)};
+             if (typeof JarbasHiveMind !== 'function') { throw new Error('not a constructor'); }
+             console.log('ok');`,
+        ], { encoding: 'utf8' });
+        assert.equal(out.trim(), 'ok');
+    });
+});


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 5 (claude-opus-5) via Claude Code — NOT human-reviewed. Verify before acting.

Three defects, all found by pointing this client at the live hub at `hivemind.openvoiceos.pt` rather than by reading code.

## 1. TLS was impossible

`connect()` built `'ws://' + host` unconditionally. No option, no mention in the readme. That locks the client out of every hub behind TLS, and a browser on an HTTPS page refuses a `ws://` socket outright as mixed content — so the client could not be used from the one place it exists for.

`host` may now carry its own scheme (`wss://hive.example.org`), and `options.ssl` selects one for a bare host. A bare host still defaults to `ws`, which is what a local hub needs.

## 2. `onMycroftSpeak` never fired

OVOS-PIPELINE-1 §9.6 renamed the spoken-response topic to `ovos.utterance.speak`. Dispatch matched only the legacy `speak`.

Python clients never noticed, because `ovos-bus-client` rewrites the old name for its subscribers. This client has no such shim, so its primary callback was silently dead against any current hub. Measured on the hub's own internal bus: only `ovos.utterance.speak` is emitted. Both names are now accepted, so older hubs keep working.

## 3. The documented ESM import threw

`package.json` declared `"module"` and an `exports` `"import"` condition pointing at a CommonJS file, so the `import { JarbasHiveMind } from 'hivemind-js'` shown in the readme failed with `Named export not found`. `static/js/hivemind.mjs` is the missing half: it re-exports the same objects, so there is one implementation and nothing to drift.

## Live verification

Against `wss://hivemind.openvoiceos.pt`, after the fix: TLS connect → protocol v3 Noise `XXpsk2` handshake → utterance sent → `onMycroftSpeak` fired with the hub's reply. Before the fix the same script could not resolve the host at all.

## Tests

`test/real_hub.test.js`. The four cases asserting the fixes all fail against unfixed `dev`; the three guarding what must not break pass either way. Full suite: 80 passing.

## Found while testing, NOT fixed here

- **The client generates a fresh Noise static key on every connection.** The hub pins a client's static key on first use (CRYPTO-1 §3.4.5), so the second connection is rejected as `client Noise static key contradicts the pinned key` and the operator must run `hivemind-core reset-noise-pin` between every run. Reproduced on the live hub. `options.noiseStaticKey` exists, but the default self-locks. This needs a persistence decision (localStorage in a browser) rather than a one-line change.
- **A server-side handshake abort is not surfaced.** When the hub rejected the pinned key and closed the socket, the client printed `connected` and then sat silent. `onHiveConnected` should not fire, or the failure should reach `onHiveError`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ES module support with named and default exports.
  * Added secure WebSocket connection options, including `ws://` and `wss://` host URLs and SSL selection.
  * Added support for both standard and legacy speech message formats.

* **Documentation**
  * Updated connection and speech-handling examples to describe the new options and supported message types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->