### PR TITLE
fix: persist the Noise static key, and surface a refused connection

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -113,7 +113,7 @@ is used; otherwise the legacy Protocol V1 handshake runs.
 |-------|------|-------------|
 | `psk` | `Uint8Array` or hex string | Optional pre-provisioned 32-byte Noise PSK. Normally unnecessary, a `password` is stretched with argon2id on-device to the same value; provide `psk` only to skip derivation or when no password is configured |
 | `serverNoiseKey` | hex string | Pinned server static X25519 public key; enables `KKpsk0` and aborts on mismatch (TOFU pinning) |
-| `noiseStaticKey` | `Uint8Array` or hex string | This node's static X25519 private key, persist it to keep a stable node identity across connections |
+| `noiseStaticKey` | `Uint8Array` or hex string | This node's static X25519 private key. Optional — when omitted, the client generates one and remembers it for you, keyed by `host`/`port`/`accessKey`: `localStorage` in the browser, an in-memory process-lifetime cache in Node.js (Node has no `localStorage`, and this library will not silently write key material to a file in your home directory — pass this option yourself if you need a Node process identity to survive a restart). An explicit value here always wins over anything stored, and is itself persisted for later connects. This matters because the server pins a client's static key on first use: regenerating it every connection gets the client locked out |
 | `maxProtocolVersion` | number | Cap the negotiated protocol version (default `3`) |
 
 Returns the raw `WebSocket` instance.
@@ -136,6 +136,7 @@ Override these on your instance before calling `connect()`:
 |------|---------------|
 | `onHiveConnected()` | Handshake complete, safe to call `sendMessage` |
 | `onHiveDisconnected()` | WebSocket closed |
+| `onHiveError(err)` | The hub refused or aborted the connection, e.g. the WebSocket closed before the handshake reached READY. A close with code `1008` means the hub rejected the credentials — treated as fatal. Fires before `onHiveDisconnected()` |
 | `onMycroftMessage(msg)` | Any `bus` message received |
 | `onMycroftSpeak(msg)` | `bus` message with type `speak` |
 | `onHiveBroadcast(msg)` | `broadcast` message received |

--- a/static/js/hivemind.js
+++ b/static/js/hivemind.js
@@ -923,6 +923,64 @@ const States = {
 };
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Noise static-key persistence (HIVEMIND-CRYPTO-1 §3.4.5: the server pins a
+// client's static key on first use, so re-generating it on every connect()
+// locks the client out after the very first successful handshake).
+//
+// Browser: localStorage, keyed by host/port/accessKey so unrelated hubs or
+// unrelated access keys on the same origin never collide, and never crash
+// the connection when storage is unavailable or throws (private mode,
+// disabled storage, quota).
+//
+// Node.js: there is no localStorage. We keep an in-memory, process-lifetime
+// cache instead of silently writing a file into the user's home directory —
+// a background client library persisting secret key material to disk without
+// being asked is a bigger surprise than "the key is fresh every process
+// restart". Callers that want a stable node identity across Node process
+// restarts must pass options.noiseStaticKey themselves (loaded from wherever
+// they choose to keep it).
+// ─────────────────────────────────────────────────────────────────────────────
+
+const _nodeNoiseStaticKeyCache = new Map(); // storageKey -> Uint8Array(32), process lifetime only
+
+function _hasLocalStorage() {
+    try {
+        return typeof localStorage !== 'undefined' && localStorage !== null;
+    } catch (e) {
+        return false;
+    }
+}
+
+function _noiseStorageKey(host, port, accessKey) {
+    return 'hivemind:noise-static-key:' + host + ':' + port + ':' + accessKey;
+}
+
+function _loadPersistedNoiseStaticKey(key) {
+    if (_hasLocalStorage()) {
+        try {
+            const hex = localStorage.getItem(key);
+            return hex ? fromHex(hex) : null;
+        } catch (e) {
+            console.warn('HiveMind: localStorage unavailable, cannot load persisted Noise static key', e);
+            return null;
+        }
+    }
+    return _nodeNoiseStaticKeyCache.has(key) ? _nodeNoiseStaticKeyCache.get(key) : null;
+}
+
+function _persistNoiseStaticKey(key, priv) {
+    if (_hasLocalStorage()) {
+        try {
+            localStorage.setItem(key, toHex(priv));
+        } catch (e) {
+            console.warn('HiveMind: localStorage unavailable, Noise static key will not persist across reloads', e);
+        }
+        return;
+    }
+    _nodeNoiseStaticKeyCache.set(key, priv);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // JarbasHiveMind — Protocol V1 client
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -963,7 +1021,16 @@ function JarbasHiveMind() {
 //   serverNoiseKey:     hex — pinned server static X25519 public key; enables the
 //                       KKpsk0 pattern and aborts on key mismatch (TOFU pinning).
 //   noiseStaticKey:     32-byte Uint8Array or hex — this node's static X25519
-//                       private key (persist it to keep a stable node identity).
+//                       private key. Optional: when omitted, the client
+//                       reuses (or generates and then persists) a key keyed
+//                       by host/port/accessKey — in localStorage in the
+//                       browser, in an in-memory process-lifetime cache in
+//                       Node.js. An explicitly supplied value always wins
+//                       over anything stored, and is persisted for later
+//                       connects too. This matters because the server pins
+//                       a client's static key on first use (HIVEMIND-CRYPTO-1
+//                       §3.4.5): re-generating it every connect() locks the
+//                       client out after the first successful handshake.
 //   maxProtocolVersion: cap the negotiated protocol version (default 3).
 JarbasHiveMind.prototype.connect = function (host, port, username, accessKey, password, options) {
     options = options || {};
@@ -982,6 +1049,22 @@ JarbasHiveMind.prototype.connect = function (host, port, username, accessKey, pa
     this._serverNoiseKey = options.serverNoiseKey || null;
     this._noiseStaticKey = typeof options.noiseStaticKey === 'string'
         ? fromHex(options.noiseStaticKey) : (options.noiseStaticKey || null);
+    // Persist/reuse the Noise static key so the client doesn't re-key (and
+    // get itself locked out) on every connect(). An explicit option always
+    // wins and gets persisted too, so future connects without the option
+    // still pick it up.
+    var noiseStorageKey = _noiseStorageKey(host, port, accessKey);
+    if (this._noiseStaticKey) {
+        _persistNoiseStaticKey(noiseStorageKey, this._noiseStaticKey);
+    } else {
+        var storedNoiseStaticKey = _loadPersistedNoiseStaticKey(noiseStorageKey);
+        if (storedNoiseStaticKey) {
+            this._noiseStaticKey = storedNoiseStaticKey;
+        } else {
+            this._noiseStaticKey = x25519GeneratePrivate();
+            _persistNoiseStaticKey(noiseStorageKey, this._noiseStaticKey);
+        }
+    }
     // fixed ephemeral key — deterministic interop tests ONLY, never production
     this._noiseEphemeralKey = typeof options._noiseEphemeralKey === 'string'
         ? fromHex(options._noiseEphemeralKey) : (options._noiseEphemeralKey || null);
@@ -1062,6 +1145,7 @@ JarbasHiveMind.prototype.sendAudioB64 = async function (base64) {
 
 JarbasHiveMind.prototype.onHiveConnected    = function ()    { console.log('HiveMind connected'); };
 JarbasHiveMind.prototype.onHiveDisconnected = function ()    { console.log('HiveMind disconnected'); };
+JarbasHiveMind.prototype.onHiveError        = function (err) { console.error('HiveMind error:', err); };
 JarbasHiveMind.prototype.onMycroftMessage   = function (msg) { console.log('mycroft message:', msg); };
 JarbasHiveMind.prototype.onMycroftSpeak     = function (msg) { console.log('mycroft speak:', msg && msg.data && msg.data.utterance); };
 JarbasHiveMind.prototype.onHiveBroadcast    = function (msg) { };
@@ -1112,11 +1196,30 @@ JarbasHiveMind.prototype._onWsMessage = async function (event) {
     }
 };
 
-JarbasHiveMind.prototype._onWsClose = function () {
+JarbasHiveMind.prototype._onWsClose = function (event) {
+    var wasReady = this._state === States.READY;
+    var closeCode = event && event.code;
     this._state = States.DISCONNECTED;
     this._sessionKey = null;
     this._noiseHandshake = null;
     this._noiseTransport = null;
+    if (!wasReady) {
+        // The socket closed before the handshake completed: the hub refused
+        // or aborted the connection. Without this, callers see "connected"
+        // (from a premature log) and then silence, with no error and no
+        // onHiveDisconnected reason to explain it.
+        var reason = (event && event.reason) ? (': ' + event.reason) : '';
+        var message;
+        if (closeCode === 1008) {
+            // HIVEMIND-WIRE-1: 1008 (Policy Violation) means the server
+            // rejected the credentials/handshake — fatal, not a transient drop.
+            message = 'HiveMind connection refused: credentials rejected by server (close code 1008)' + reason;
+        } else {
+            message = 'HiveMind connection refused before handshake completed (close code ' +
+                (closeCode !== undefined ? closeCode : 'unknown') + ')' + reason;
+        }
+        this.onHiveError(new Error(message));
+    }
     this.onHiveDisconnected();
 };
 

--- a/test/noise-persistence.test.js
+++ b/test/noise-persistence.test.js
@@ -1,0 +1,173 @@
+'use strict';
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+
+// ── MockWebSocket ─────────────────────────────────────────────────────────────
+// Same minimal pattern as test/handshake.test.js — no real network needed for
+// these tests, which only exercise connect()'s key-persistence bookkeeping and
+// the pre-READY close → onHiveError path.
+
+let _lastMockWs = null;
+
+class MockWebSocket {
+    constructor(url) {
+        this.url  = url;
+        this.sent = [];
+        this.onopen    = null;
+        this.onmessage = null;
+        this.onclose   = null;
+        _lastMockWs = this;
+    }
+
+    send(data) { this.sent.push(data); }
+
+    triggerOpen()  { if (this.onopen)  this.onopen(); }
+    triggerClose(event) { if (this.onclose) this.onclose(event); }
+}
+
+globalThis.WebSocket = MockWebSocket;
+
+// ── Fake localStorage ──────────────────────────────────────────────────────────
+
+class FakeLocalStorage {
+    constructor() { this._map = new Map(); }
+    getItem(key) { return this._map.has(key) ? this._map.get(key) : null; }
+    setItem(key, value) { this._map.set(key, value); }
+    removeItem(key) { this._map.delete(key); }
+}
+
+class ThrowingLocalStorage {
+    getItem()  { throw new Error('storage disabled (private mode)'); }
+    setItem()  { throw new Error('storage disabled (private mode)'); }
+}
+
+const { JarbasHiveMind } = require('../static/js/hivemind.js');
+
+describe('Noise static key persistence', () => {
+    test('a stored key is reused on a second connect (browser localStorage path)', () => {
+        globalThis.localStorage = new FakeLocalStorage();
+        try {
+            const hm1 = new JarbasHiveMind();
+            hm1.connect('hub.example', 5678, 'user', 'access-key-1', 'pw');
+            const firstKey = hm1._noiseStaticKey;
+            assert.ok(firstKey instanceof Uint8Array);
+            assert.equal(firstKey.length, 32);
+
+            const hm2 = new JarbasHiveMind();
+            hm2.connect('hub.example', 5678, 'user', 'access-key-1', 'pw');
+            const secondKey = hm2._noiseStaticKey;
+
+            assert.deepEqual(Array.from(secondKey), Array.from(firstKey));
+        } finally {
+            delete globalThis.localStorage;
+        }
+    });
+
+    test('different access keys on the same origin do not collide', () => {
+        globalThis.localStorage = new FakeLocalStorage();
+        try {
+            const hmA = new JarbasHiveMind();
+            hmA.connect('hub.example', 5678, 'user', 'access-key-A', 'pw');
+
+            const hmB = new JarbasHiveMind();
+            hmB.connect('hub.example', 5678, 'user', 'access-key-B', 'pw');
+
+            assert.notDeepEqual(Array.from(hmA._noiseStaticKey), Array.from(hmB._noiseStaticKey));
+        } finally {
+            delete globalThis.localStorage;
+        }
+    });
+
+    test('an explicit noiseStaticKey overrides the stored one, and is persisted for later', () => {
+        globalThis.localStorage = new FakeLocalStorage();
+        try {
+            const hm1 = new JarbasHiveMind();
+            hm1.connect('hub.example', 5678, 'user', 'access-key-2', 'pw');
+            const storedKey = hm1._noiseStaticKey;
+
+            const explicitKey = new Uint8Array(32).fill(0x42);
+            const hm2 = new JarbasHiveMind();
+            hm2.connect('hub.example', 5678, 'user', 'access-key-2', 'pw', { noiseStaticKey: explicitKey });
+
+            assert.deepEqual(Array.from(hm2._noiseStaticKey), Array.from(explicitKey));
+            assert.notDeepEqual(Array.from(hm2._noiseStaticKey), Array.from(storedKey));
+
+            // The explicit key must now be what gets reused, since it was persisted too.
+            const hm3 = new JarbasHiveMind();
+            hm3.connect('hub.example', 5678, 'user', 'access-key-2', 'pw');
+            assert.deepEqual(Array.from(hm3._noiseStaticKey), Array.from(explicitKey));
+        } finally {
+            delete globalThis.localStorage;
+        }
+    });
+
+    test('unavailable/throwing localStorage does not break connecting', () => {
+        globalThis.localStorage = new ThrowingLocalStorage();
+        try {
+            const hm = new JarbasHiveMind();
+            assert.doesNotThrow(() => {
+                hm.connect('hub.example', 5678, 'user', 'access-key-3', 'pw');
+            });
+            assert.ok(hm._noiseStaticKey instanceof Uint8Array);
+            assert.equal(hm._noiseStaticKey.length, 32);
+        } finally {
+            delete globalThis.localStorage;
+        }
+    });
+
+    test('Node.js path (no localStorage) reuses a per-process in-memory key', () => {
+        assert.equal(typeof globalThis.localStorage, 'undefined');
+
+        const hm1 = new JarbasHiveMind();
+        hm1.connect('hub.example', 5678, 'user', 'access-key-node', 'pw');
+        const firstKey = hm1._noiseStaticKey;
+
+        const hm2 = new JarbasHiveMind();
+        hm2.connect('hub.example', 5678, 'user', 'access-key-node', 'pw');
+        const secondKey = hm2._noiseStaticKey;
+
+        assert.deepEqual(Array.from(secondKey), Array.from(firstKey));
+    });
+});
+
+describe('Pre-READY close is surfaced', () => {
+    test('a close before the handshake reaches READY calls onHiveError, not just onHiveDisconnected', () => {
+        const hm = new JarbasHiveMind();
+        let errorMessage = null;
+        let connectedCalled = false;
+        hm.onHiveError = (err) => { errorMessage = err && err.message; };
+        hm.onHiveConnected = () => { connectedCalled = true; };
+
+        hm.connect('hub.example', 5678, 'user', 'access-key', 'pw');
+        const ws = _lastMockWs;
+        ws.triggerOpen();
+
+        ws.triggerClose({ code: 1008, reason: 'invalid credentials' });
+
+        assert.ok(errorMessage, 'onHiveError should have been called');
+        assert.match(errorMessage, /1008/);
+        assert.match(errorMessage, /refused/i);
+        assert.equal(connectedCalled, false);
+        assert.notEqual(hm._state, undefined);
+    });
+
+    test('a close after READY does not call onHiveError (normal disconnect)', () => {
+        // We don't run a full handshake here — just assert that the guard is
+        // state-based: forcing _state to READY before the close means no
+        // spurious error for an ordinary post-handshake disconnect.
+        const { States } = require('../static/js/hivemind.js');
+        const hm = new JarbasHiveMind();
+        let errorCalled = false;
+        hm.onHiveError = () => { errorCalled = true; };
+
+        hm.connect('hub.example', 5678, 'user', 'access-key', 'pw');
+        const ws = _lastMockWs;
+        ws.triggerOpen();
+        hm._state = States.READY;
+
+        ws.triggerClose({ code: 1000, reason: 'normal closure' });
+
+        assert.equal(errorCalled, false);
+    });
+});


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 5 (claude-opus-5) via Claude Code — NOT human-reviewed. Verify before acting.

## The client locked itself out on its second connection

`connect()` generated a fresh X25519 static key every time. The server pins a client's static key on first use (HIVEMIND-CRYPTO-1 §3.4.5), so connection two was refused with `client Noise static key contradicts the pinned key` and an operator had to run `hivemind-core reset-noise-pin` between every single run. Reproduced against a live hub.

The key is now persisted and reused, namespaced by `host:port:accessKey` so unrelated hubs — or two access keys on one origin — never collide. An explicit `options.noiseStaticKey` always wins, and is itself persisted for later connects.

**Browser:** `localStorage`, wrapped so that unavailable or throwing storage (private mode, disabled storage, quota) falls back to a fresh in-session key rather than breaking the connection.

**Node.js:** an in-memory cache for the process lifetime, and deliberately **no file persistence**. A client library silently writing secret key material into a user's home directory is a bigger surprise than a key that regenerates on process restart. A Node caller that wants a stable identity across restarts passes `options.noiseStaticKey`, sourced wherever it chooses.

## A refused connection said nothing

When the hub aborted the handshake and closed the socket, the client logged `connected` and then sat silent. There was no `onHiveError` hook at all. A close arriving before the handshake reaches `READY` now builds an `Error` and calls `onHiveError` before `onHiveDisconnected`, with close code 1008 reported as credentials refused and fatal rather than as a transient drop.

## Tests

`test/noise-persistence.test.js`, 7 cases: stored-key reuse, access-key namespacing, an explicit key overriding and persisting itself, throwing/unavailable storage not breaking connect, the Node in-memory path, a pre-READY close reaching `onHiveError` with 1008 handling, and a negative control that a post-READY close does *not* fire it.

Six of the seven fail against unfixed `dev` — verified independently by patch revert, with the negative control correctly still passing. Suite: 80 passing (73 baseline + 7).

`readme.md` updated so the documented `noiseStaticKey` behaviour matches, with `onHiveError` added to the hooks table.

## Merge note

Merges cleanly with #16; the two touch disjoint regions.